### PR TITLE
changed esc functionality to remove last chronological filter, small clean

### DIFF
--- a/assets/js/components/GlobalFilters.vue
+++ b/assets/js/components/GlobalFilters.vue
@@ -255,12 +255,12 @@ export default Vue.extend({
       }
     },
 
-    removeOneFilter(type) {
-      for(var i=0; i<this.chronologicalFilters.length; i++) {
-        if(this.chronologicalFilters[i].type === type) {
-          this.chronologicalFilters.splice(i, 1);
-          break;
-        }
+    removeOneFilter(filterType) {
+      const index = this.chronologicalFilters.findIndex(isMatchingType);
+      this.chronologicalFilters.splice(index, 1);
+
+      function isMatchingType(filter) {
+        return filter.type === filterType;
       }
     }
   },

--- a/assets/js/components/GlobalFilters.vue
+++ b/assets/js/components/GlobalFilters.vue
@@ -144,7 +144,7 @@ export default Vue.extend({
   beforeCreate() {
     const $this = this
     this.format_pa = function(programme_area) {
-      // return _programme_areas[programme_area]['short_name'];
+      return _programme_areas[programme_area]['short_name'];
     };
     this.get_country = function(country_code) {
       return COUNTRIES[country_code]['name'];
@@ -188,12 +188,12 @@ export default Vue.extend({
     const self = this;
     this.chronologicalFilters = [];
 
-    this.makeChronologicalFiltersFromCache();
+    this.makeChronologicalFiltersFromExisting();
     this.handleEsc();
   },
 
   methods: {
-    makeChronologicalFiltersFromCache() {
+    makeChronologicalFiltersFromExisting() {
       for(var i in this.filters) {
         if(this.filters[i]) {
           this.chronologicalFilters.push({type: i, val: this.filters[i]});
@@ -244,7 +244,7 @@ export default Vue.extend({
     // but if it is changed after remove, the new one will be added as the most recent
     handleFilter(type, val, old) {
       if(old) {
-        this.removeFilterFromChronoList(type, val);
+        this.removeOneFilter(type, val);
         if(val) {
           this.chronologicalFilters.push({type, val});
         }
@@ -255,7 +255,7 @@ export default Vue.extend({
       }
     },
 
-    removeFilterFromChronoList(type, val) {
+    removeOneFilter(type, val) {
       for(var i=0; i<this.chronologicalFilters.length; i++) {
         if(this.chronologicalFilters[i].type === type) {
           this.chronologicalFilters.splice(i, 1);

--- a/assets/js/components/GlobalFilters.vue
+++ b/assets/js/components/GlobalFilters.vue
@@ -194,9 +194,9 @@ export default Vue.extend({
 
   methods: {
     makeChronologicalFiltersFromExisting() {
-      for(var i in this.filters) {
+      for(const i in this.filters) {
         if(this.filters[i]) {
-          this.chronologicalFilters.push({type: i, val: this.filters[i]});
+          this.chronologicalFilters.push({type: i});
         }
       }
     },
@@ -244,21 +244,22 @@ export default Vue.extend({
     // but if it is changed after remove, the new one will be added as the most recent
     handleFilter(type, val, old) {
       if(old) {
-        this.removeOneFilter(type, val);
+        this.removeOneFilter(type);
         if(val) {
-          this.chronologicalFilters.push({type, val});
+          this.chronologicalFilters.push({type});
         }
       } else {
         if(val) {
-          this.chronologicalFilters.push({type, val});
+          this.chronologicalFilters.push({type});
         }
       }
     },
 
-    removeOneFilter(type, val) {
+    removeOneFilter(type) {
       for(var i=0; i<this.chronologicalFilters.length; i++) {
         if(this.chronologicalFilters[i].type === type) {
           this.chronologicalFilters.splice(i, 1);
+          break;
         }
       }
     }

--- a/assets/js/components/Sectors.vue
+++ b/assets/js/components/Sectors.vue
@@ -776,7 +776,7 @@ export default Chart.extend({
               const c = d.data.colour;
               if (this.isActiveArea(d)) return c;
               return colour2gray(c, this.inactive_opacity);
-            })
+            } )
         }
       }
 
@@ -810,9 +810,9 @@ export default Chart.extend({
         // we can't use this._arc directly as it yields funky distortions,
         // so we need a custom interpolation. attrTween to the rescue
         .attrTween('d', function(d) {
-          const interpolate = d3.interpolate(
-            this._prev, $this._extract_coords(d)
-          );
+	  const interpolate = d3.interpolate(
+	    this._prev, $this._extract_coords(d)
+	  );
           this._prev = interpolate(0);
 
           return function(x) {

--- a/assets/js/components/Sectors.vue
+++ b/assets/js/components/Sectors.vue
@@ -776,7 +776,7 @@ export default Chart.extend({
               const c = d.data.colour;
               if (this.isActiveArea(d)) return c;
               return colour2gray(c, this.inactive_opacity);
-            } )
+            })
         }
       }
 
@@ -810,9 +810,9 @@ export default Chart.extend({
         // we can't use this._arc directly as it yields funky distortions,
         // so we need a custom interpolation. attrTween to the rescue
         .attrTween('d', function(d) {
-	  const interpolate = d3.interpolate(
-	    this._prev, $this._extract_coords(d)
-	  );
+          const interpolate = d3.interpolate(
+            this._prev, $this._extract_coords(d)
+          );
           this._prev = interpolate(0);
 
           return function(x) {


### PR DESCRIPTION
corresponds to issue #401.
- keep track of all filters applied or removed, chronologically in a new list
- if a previous same type filter is removed, then it will be removed from the list
- if a previous same type filter is changed, then the old one will be removed, the new one will be added as the most recent